### PR TITLE
AWS host: Return the right status

### DIFF
--- a/src/aiohabit/providers/aws.py
+++ b/src/aiohabit/providers/aws.py
@@ -25,6 +25,7 @@ from aiohabit.host import (
     STATUS_PROVISIONING,
     STATUS_DELETED,
     STATUS_ERROR,
+    STATUS_OTHER,
 )
 
 
@@ -213,7 +214,7 @@ class AWSProvider(Provider):
             host_info.get("id"),
             host_info.get("name"),
             host_info.get("addresses"),
-            host_info.get("status"),
+            STATUS_MAP.get(host_info.get("status"), STATUS_OTHER),
             provisioning_result,
             error_obj=host_info.get("fault"),
         )


### PR DESCRIPTION
Fixing a small issue, `STATUS_MAP` was defined but not used. 

Issue described at https://github.com/pvoborni/aiohabit/pull/8#issuecomment-663308754.