### PR TITLE
Handle output action error + Update logger format

### DIFF
--- a/src/mrack/__init__.py
+++ b/src/mrack/__init__.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 file_formatter = logging.Formatter("%(asctime)s %(name)s %(message)s")
-console_formatter = logging.Formatter("%(name)s %(message)s")
+console_formatter = logging.Formatter("%(message)s")
 
 file_handler = logging.FileHandler("mrack.log")
 file_handler.setFormatter(file_formatter)

--- a/src/mrack/actions/output.py
+++ b/src/mrack/actions/output.py
@@ -15,6 +15,7 @@
 """Output action."""
 import logging
 
+from mrack.errors import MetadataError
 from mrack.outputs.ansible_inventory import AnsibleInventoryOutput
 from mrack.outputs.pytest_multihost import PytestMultihostOutput
 
@@ -37,6 +38,10 @@ class Output:
     async def generate_outputs(self):
         """Generate outputs."""
         logger.info("Output generation started")
+
+        if not self._db_driver.hosts:
+            raise MetadataError("No hosts found.")
+
         ansible_o = AnsibleInventoryOutput(
             self._config, self._db_driver, self._metadata
         )

--- a/src/mrack/outputs/pytest_multihost.py
+++ b/src/mrack/outputs/pytest_multihost.py
@@ -14,6 +14,7 @@
 
 """pytest-multihost configuration file output module."""
 
+import logging
 import os
 from copy import deepcopy
 
@@ -21,6 +22,8 @@ from mrack.outputs.utils import resolve_hostname
 from mrack.utils import get_password, get_username, save_yaml
 
 DEFAULT_MHCFG_PATH = "pytest-multihost.yaml"
+
+logger = logging.getLogger(__name__)
 
 
 class PytestMultihostOutput:
@@ -77,7 +80,10 @@ class PytestMultihostOutput:
 
         for domain in mhcfg["domains"]:
             for host in domain["hosts"]:
-                provisioned_host = self._db.hosts[host["name"]]
+                provisioned_host = self._db.hosts.get(host["name"])
+                if not provisioned_host:
+                    logger.error(f"Host {host['name']} not found in the database.")
+                    continue
 
                 username = get_username(provisioned_host, host, self._config)
                 password = get_password(provisioned_host, host, self._config)


### PR DESCRIPTION
- Print message only
- Handle output action error
  - Running `mrack output` with an empty database breaks `python-pytest-multihost` config file. (E.g: Not running `mrack up` before trying that.)