### PR TITLE
Set defaults for pytest and remove xunit1 format warning message

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
 
 - script: |
     pip install .
-    pytest
+    pytest --junit-xml=TEST-pytest.xml
   displayName: 'pytest'
 
 - script: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -r fEsxXw --showlocals
+junit_family = xunit2
+testpaths =
+    tests


### PR DESCRIPTION
Set defaults for pytest and remove xunit1 format warning message
    
So that we can more easily inspect in azure if new tests were run  properly and also be able to see the results.
    
Mainly it removes warning message about deprecating xunit1 format.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>