### PR TITLE
Use public AWS addresses instead of private ones and add some minor fixes to aws

### DIFF
--- a/src/mrack/transformers/aws.py
+++ b/src/mrack/transformers/aws.py
@@ -27,16 +27,22 @@ class AWSTransformer(Transformer):
     _required_config_attrs = [
         "flavors",
         "images",
-        "keypair",
         "credentials_file",
+        "keypair",
+        "security_group",
         "profile",
-        "tags",
+        "instance_tags",
     ]
 
     async def init_provider(self):
         """Initialize associate provider."""
         images = self.config["images"].values()
-        await self._provider.init(image_names=images)
+        await self._provider.init(
+            image_names=images,
+            ssh_key=self.config["keypair"],
+            sec_group=self.config["security_group"],
+            instance_tags=self.config["instance_tags"],
+        )
 
     def _get_flavor(self, host):
         """Get flavor by host group."""


### PR DESCRIPTION
Using private addresses will result into unreachable host
without vpn tunnel or mechanism to access AWS network.

Add security group, tags, keypair to init of AWS provider.
They have to be defined in provisioning config.

Remove asserts and replace them with ProvisioningErrors

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>