### PR TITLE
Add username='root' to fix ansible user

### DIFF
--- a/src/mrack/transformers/beaker.py
+++ b/src/mrack/transformers/beaker.py
@@ -29,7 +29,11 @@ class BeakerTransformer(Transformer):
 
     async def init_provider(self):
         """Initialize associate provider."""
-        await self._provider.init(self.config)
+        await self._provider.init(
+            self.config["max_attempts"],
+            self.config["reserve_duration"],
+            self.config["keypair"],
+        )
 
     def _get_distro(self, os):
         """Get distro string by OS name from provisioning config."""
@@ -50,7 +54,7 @@ class BeakerTransformer(Transformer):
             "name": host["name"],
             "distro": self._get_distro(host["os"]),
             "arch": host.get("arch", "x86_64"),
-            "variant": self._get_variant(host)
+            "variant": self._get_variant(host),
         }
 
     def create_host_requirements(self):


### PR DESCRIPTION
Add username='root' to fix ansible user

Added username='root' to beaker host object initialization
so inventory is created using ansible_user: root.
This is required because we are uploading public key
while provisioning to the root user and not user set
in the provisioning config.
The mismatched user causes unreachable host
when using generated ansible inventory.

Fix initialization of provider in a way
that we do not pass provisioning config
but only needed values.

Add status Queued as provisioning.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>