### PR TITLE
Remove false warnings produced by isort in make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 format:
-	isort src
-	isort tests
+	isort --recursive src
+	isort --recursive tests
 	black src
 	black tests
 	black setup.py


### PR DESCRIPTION
Before:

```
$ make format
isort src
WARNING: Unable to parse file src due to [Errno 21] Is a directory: '/home/pvoborni/dev/freeipa/mrack/src'
isort tests
WARNING: Unable to parse file tests due to [Errno 21] Is a directory: '/home/pvoborni/dev/freeipa/mrack/tests'
black src
...
```
After:
```
$ make format
isort --recursive src
isort --recursive tests
black src
...
```