### PR TITLE
ansible-inventory: rework generation of groups

### DIFF
--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -1,0 +1,162 @@
+import uuid
+
+from mrack.config import ProvisioningConfig
+from mrack.dbdrivers.file import FileDBDriver
+from mrack.host import STATUS_ACTIVE, Host
+
+
+class MockProvider:
+    """Mock provider for working in DB."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+def create_metadata(ipaservers, ipaclients, ads):
+    """
+    Generate example metadata, using FreeIPA as example project.
+    """
+
+    domain_name = "example.test"
+    addomain_name = "adexample.test"
+    fedora = "fedora-31"
+
+    ipa_hosts = []
+    ipadomain = {
+        "name": domain_name,
+        "type": "ipa",
+        "hosts": ipa_hosts,
+    }
+
+    for i in range(ipaservers):
+        host = {
+            "name": f"ipaserver{i}@{domain_name}",
+            "os": fedora,
+            "role": "ipaserver",
+            "groups": ["ipaserver"],
+        }
+        ipa_hosts.append(host)
+
+    for i in range(ipaclients):
+        host = {
+            "name": f"ipaclient{i}@{domain_name}",
+            "os": fedora,
+            "role": "ipaclient",
+            "groups": ["ipaclient"],
+        }
+        ipa_hosts.append(host)
+
+    ad_hosts = []
+    addomain = {
+        "name": addomain_name,
+        "type": "ad",
+        "hosts": ad_hosts,
+    }
+
+    for i in range(ads):
+        host = {
+            "name": f"ad{i}@{addomain_name}",
+            "os": "windows",
+            "role": "ad",
+            "groups": ["win-2019"],
+        }
+        ad_hosts.append(host)
+
+    domains = []
+
+    if ipaservers or ipaclients:
+        domains.append(ipadomain)
+    if ads:
+        domains.append(addomain)
+
+    return {
+        "domains": domains,
+    }
+
+
+def get_ip(index=0):
+    """Get IPv4 IP from 192.168.0/24 network."""
+    return f"192.168.0.{index+1}"
+
+
+def create_db_host(
+    hostname,
+    index=0,
+    status=STATUS_ACTIVE,
+    username=None,
+    password=None,
+    provider="openstack",
+):
+    """Create Host object based on minimal info."""
+
+    return Host(
+        MockProvider(provider),
+        uuid.uuid4(),
+        hostname,
+        [get_ip(index)],
+        status,
+        {},
+        username=username,
+        password=password,
+        error_obj=None,
+    )
+
+
+def create_db(hostnames, provider="openstack"):
+    """Create artificial DB based on hostnames."""
+    db = FileDBDriver("mock_path")
+    db.save_on_change = False  # to prevent attempt to save when adding hosts
+
+    for index, hostname in enumerate(hostnames):
+        host = create_db_host(hostname, index, provider=provider)
+        db.add_hosts([host])
+    return db
+
+
+def get_db_from_metadata(metadata, provider="openstack"):
+    """Create DB from metadata for testing."""
+    hostnames = []
+    for domain in metadata.get("domains", []):
+        for host in domain.get("hosts", []):
+            hostnames.append(host["name"])
+
+    db = create_db(hostnames)
+    return db
+
+
+def common_inventory_layout():
+    """Get common inventory layour for testing FreeIPA project."""
+    return {
+        "all": {
+            "children": {
+                "ipa": {"children": {"ipaserver": {}, "ipaclient": {}}},
+                "linux": {"children": {"ipa": {}, "sssd": {}}},
+                "windows": {"children": {"ad": {}, "client": {}}},
+            }
+        }
+    }
+
+
+def provisioning_config(inventory_layout=None):
+    """Get basic provisioning config for testing."""
+    cfg = {
+        "ssh_key_filename": "config/id_rsa",
+        "users": {
+            "fedora-30": "fedora",
+            "fedora-31": "fedora",
+            "rhel-8.2": "cloud-user",
+            "win-2019": "Administrator",
+            "default": "cloud-user",
+        },
+        "python": {
+            "fedora-30": "/usr/bin/python3",
+            "fedora-31": "/usr/bin/python3",
+            "rhel-8.2": "/usr/libexec/platform-python",
+            "default": "/usr/bin/python3",
+        },
+    }
+    if inventory_layout:
+        cfg["inventory_layout"] = inventory_layout
+
+    config = ProvisioningConfig(cfg)
+    return config

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -1,0 +1,120 @@
+import pytest
+
+from mrack.errors import ConfigError
+from mrack.outputs.ansible_inventory import AnsibleInventoryOutput, get_group
+
+from .mock_data import (
+    common_inventory_layout,
+    create_metadata,
+    get_db_from_metadata,
+    provisioning_config,
+)
+
+
+def ensure_all_groups_present(metadata, inventory):
+    """
+    Ensure that all groups defined in metadata hosts objects are present.
+
+    And contain the host
+    """
+    for domain in metadata["domains"]:
+        for meta_host in domain["hosts"]:
+            for groupname in meta_host.get("groups"):
+                group = get_group(inventory, groupname)
+                assert group, "All defined groups in host must be in inventory"
+                assert "hosts" in group, "Group must contain hosts dict"
+                hosts = group["hosts"]
+                assert meta_host["name"] in hosts, "Group must contain the host"
+
+
+def ensure_hosts_in_all_group(db, inventory):
+    """Ensure that group 'all' contains all hosts from DB."""
+    all_group = inventory["all"]
+    hosts = all_group["hosts"]
+    db_hosts = db.hosts
+
+    assert len(db_hosts) > 0, "Make sure we do not work on empty data set"
+
+    required_attrs = [
+        "ansible_host",
+        "ansible_python_interpreter",
+        "ansible_user",
+        "meta_domain",
+        "meta_fqdn",
+        "meta_os",
+        "meta_ip",
+        "meta_provider_id",
+        "meta_role",
+    ]
+
+    for name, dbhost in db_hosts.items():
+        assert dbhost.name in hosts, "All hosts must be present in inventory"
+
+        invhost = hosts[dbhost.name]
+
+        assert dbhost.ip == invhost["meta_ip"], "IP from DB in inventory"
+        for attr in required_attrs:
+            assert attr in required_attrs, "All required attrs are in host definition"
+
+
+@pytest.fixture()
+def metadata():
+    return create_metadata(ipaservers=1, ipaclients=1, ads=1)
+
+
+@pytest.fixture()
+def db(metadata):
+    return get_db_from_metadata(metadata)
+
+
+def empty_layout():
+    return {
+        "all": {},
+    }
+
+
+class TestAnsibleInventory:
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            # It is more tolerant with falsy values
+            common_inventory_layout(),
+            None,
+            {},
+            empty_layout(),
+            [],
+            False,
+        ],
+    )
+    def test_layouts(self, layout, db, metadata):
+
+        config = provisioning_config(layout)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        assert "all" in inventory, "Inventory must have group 'all'"
+        all_group = inventory["all"]
+        assert "hosts" in all_group, "All group must have 'hosts' dict"
+        assert "children" in all_group, "All group must have 'children' dict"
+
+        ensure_all_groups_present(metadata, inventory)
+        ensure_hosts_in_all_group(db, inventory)
+
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            # Non-dict truthy values are not valid
+            ["test"],
+            "test",
+            True,
+            (True, False),
+        ],
+    )
+    def test_invalid_layouts(self, layout, db, metadata):
+
+        config = provisioning_config(layout)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+
+        with pytest.raises(ConfigError) as excinfo:
+            ans_inv.create_inventory()
+        assert "dictionary" in str(excinfo.value)


### PR DESCRIPTION
The Ansible inventory output was not correctly adding hosts into groups. E.g.
group was not added when it was not defined in layout. Nested group was not
correctly found and host added.

This part is completely reworked and changes the behavior to:
- add only a host name reference (no vars) into custom groups
- add missing groups as children of 'all' group
- works with both "groups" and "group" defined in metadata
- add all hosts to 'all' with also variables. This ensures that the full host
  object is defined only once.

Doc: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>