### PR TITLE
Refactor providers to share same code

### DIFF
--- a/src/mrack/providers/aws.py
+++ b/src/mrack/providers/aws.py
@@ -14,7 +14,6 @@
 
 """AWS Provider interface."""
 
-import asyncio
 import logging
 from copy import deepcopy
 from datetime import datetime
@@ -28,22 +27,12 @@ from mrack.host import (
     STATUS_ERROR,
     STATUS_OTHER,
     STATUS_PROVISIONING,
-    Host,
 )
 from mrack.providers.provider import Provider
 
 logger = logging.getLogger(__name__)
 
 PROVISIONER_KEY = "aws"
-
-STATUS_MAP = {
-    "running": STATUS_ACTIVE,
-    "pending": STATUS_PROVISIONING,
-    "terminated": STATUS_DELETED,
-    "error": STATUS_ERROR,
-    # there is much more we can treat it as STATUS_OTHER, see statuses:
-    # pending | running | shutting-down | terminated | stopping | stopped
-}
 
 
 class AWSProvider(Provider):
@@ -56,6 +45,14 @@ class AWSProvider(Provider):
         self.ssh_key = None
         self.sec_group = None
         self.instance_tags = None
+        self.STATUS_MAP = {
+            "running": STATUS_ACTIVE,
+            "pending": STATUS_PROVISIONING,
+            "terminated": STATUS_DELETED,
+            "error": STATUS_ERROR,
+            # there is much more we can treat it as STATUS_OTHER, see statuses:
+            # pending | running | shutting-down | terminated | stopping | stopped
+        }
 
     @property
     def name(self):
@@ -80,6 +77,10 @@ class AWSProvider(Provider):
     async def validate_hosts(self, hosts):
         """Validate that host requirements are well specified."""
         return
+
+    async def can_provision(self, hosts):
+        """Check that hosts can be provisioned."""
+        return True
 
     async def create_server(self, req):
         """Issue creation of a server.
@@ -115,8 +116,8 @@ class AWSProvider(Provider):
         # returns id of provisioned instance
         return ids[0]
 
-    def _get_host_info_from_prov_result(self, prov_result):
-        """Get needed host infromation from AWS provisioning result."""
+    def prov_result_to_host_data(self, prov_result):
+        """Transform provisioning result to needed host data."""
         # init the dict
         result = {
             "id": None,
@@ -135,90 +136,34 @@ class AWSProvider(Provider):
 
         return result
 
+    def parse_errors(self, server_results):
+        """Parse provisioning errors from provider result."""
+        errors = []
+        for res in server_results:
+            if self.STATUS_MAP.get(res["State"]["Name"], STATUS_OTHER) == STATUS_ERROR:
+                errors.append(res)
+
+        return errors
+
     async def wait_till_provisioned(self, aws_id):
         """Wait for AWS provisioning result."""
         instance = self.ec2.Instance(aws_id)
         instance.wait_until_running()
         response = self.client.describe_instances(InstanceIds=[aws_id])
-
+        result = {}
         try:  # returns dict with aws instance information
-            return response["Reservations"][0]["Instances"][0]
+            result = response["Reservations"][0]["Instances"][0]
         except (KeyError, IndexError):
             raise ProvisioningError(
                 "Unexpected data format in response of provisioned instance."
             )
 
-    async def provision_hosts(self, hosts):
-        """Provision hosts based on list of host requirements.
-
-        Issues provisioning and waits for it succeed. Raises exception if any of
-        the servers was not successfully provisioned. If that happens it issues deletion
-        of all already provisioned resources.
-
-        Return list of information about provisioned servers.
-        """
-        started = datetime.now()
-
-        count = len(hosts)
-        logger.info(f"Issuing provisioning of {count} hosts")
-        create_aws = []
-        for req in hosts:
-            aws = self.create_server(req)
-            create_aws.append(aws)
-        create_resps = await asyncio.gather(*create_aws)
-        logger.info("Provisioning issued")
-        logger.info(create_resps)
-
-        logger.info("Waiting for all AWS hosts to be available")
-        wait_aws = []
-        for create_resp in create_resps:
-            aws = self.wait_till_provisioned(create_resp)
-            wait_aws.append(aws)
-
-        server_results = await asyncio.gather(*wait_aws)
-
-        provisioned = datetime.now()
-        provi_duration = provisioned - started
-
-        logger.info("All AWS hosts reached provisioning final state (running)")
-        logger.info(f"Provisioning duration: {provi_duration}")
-
-        hosts = [self.to_host(srv) for srv in server_results]
-        for host in hosts:
-            logger.info(host)
-
-        return hosts
+        return result
 
     async def delete_host(self, host):
         """Delete provisioned hosts based on input from provision_hosts."""
-        logger.info(f"Deleting AWS host {host.id}")
+        logger.info(f"Terminating AWS host {host.id}")
         ids = [host._id]
         self.ec2.instances.filter(InstanceIds=ids).stop()
         self.ec2.instances.filter(InstanceIds=ids).terminate()
         return True
-
-    async def delete_hosts(self, hosts):
-        """Issue deletion of all servers based on previous results from provisioning."""
-        logger.info("Issuing AWS deletion")
-        delete_aws = []
-        for host in hosts:
-            aws = self.delete_host(host)
-            delete_aws.append(aws)
-        results = await asyncio.gather(*delete_aws)
-        logger.info("All AWS servers issued to be deleted")
-        return results
-
-    def to_host(self, provisioning_result):
-        """Transform provisioning result into Host object."""
-        host_info = self._get_host_info_from_prov_result(provisioning_result)
-
-        host = Host(
-            self,
-            host_info.get("id"),
-            host_info.get("name"),
-            host_info.get("addresses"),
-            STATUS_MAP.get(host_info.get("status"), STATUS_OTHER),
-            provisioning_result,
-            error_obj=host_info.get("fault"),
-        )
-        return host

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -23,14 +23,13 @@ from urllib.parse import parse_qs, urlparse
 from asyncopenstackclient import AuthPassword, GlanceClient
 from simple_rest_client.exceptions import NotFoundError
 
-from mrack.errors import ProvisioningError, ServerNotFoundError, ValidationError
+from mrack.errors import ServerNotFoundError, ValidationError
 from mrack.host import (
     STATUS_ACTIVE,
     STATUS_DELETED,
     STATUS_ERROR,
     STATUS_OTHER,
     STATUS_PROVISIONING,
-    Host,
 )
 from mrack.providers.provider import Provider
 from mrack.providers.utils.osapi import ExtraNovaClient, NeutronClient
@@ -43,16 +42,6 @@ logger = logging.getLogger(__name__)
 
 
 PROVISIONER_KEY = "openstack"
-
-
-STATUS_MAP = {
-    "ACTIVE": STATUS_ACTIVE,
-    "BUILD": STATUS_PROVISIONING,
-    "DELETED": STATUS_DELETED,
-    "ERROR": STATUS_ERROR,
-    # there is much more we can treat it as STATUS_OTHER, see:
-    # https://docs.openstack.org/api-guide/compute/server_concepts.html
-}
 
 
 class OpenStackProvider(Provider):
@@ -78,6 +67,14 @@ class OpenStackProvider(Provider):
         self.timeout = 60  # minutes
         self.poll_sleep_initial = 15  # seconds
         self.poll_sleep = 7  # seconds
+        self.STATUS_MAP = {
+            "ACTIVE": STATUS_ACTIVE,
+            "BUILD": STATUS_PROVISIONING,
+            "DELETED": STATUS_DELETED,
+            "ERROR": STATUS_ERROR,
+            # there is much more we can treat it as STATUS_OTHER, see:
+            # https://docs.openstack.org/api-guide/compute/server_concepts.html
+        }
 
     async def init(self, image_names=None):
         """Initialize provider with data from OpenStack.
@@ -371,8 +368,17 @@ class OpenStackProvider(Provider):
             logger.warning(f"Server '{uuid}' not found, probably already deleted")
             pass
 
+    def parse_errors(self, server_results):
+        """Parse provisioning errors from provider result."""
+        errors = []
+        for res in server_results:
+            if self.STATUS_MAP.get(res["status"], STATUS_OTHER) == STATUS_ERROR:
+                errors.append(res)
+
+        return errors
+
     async def wait_till_provisioned(
-        self, uuid, timeout=None, poll_sleep=None, poll_sleep_initial=None
+        self, instance, timeout=None, poll_sleep=None, poll_sleep_initial=None
     ):
         """
         Wait till server is provisioned.
@@ -389,6 +395,7 @@ class OpenStackProvider(Provider):
 
         Return information about provisioned server.
         """
+        uuid = instance.get("id")
         if not poll_sleep_initial:
             poll_sleep_initial = self.poll_sleep_initial
         if not poll_sleep:
@@ -426,127 +433,27 @@ class OpenStackProvider(Provider):
 
         return server
 
-    def get_poll_sleep_times(self, hosts):
-        """Compute polling sleep times based on number of hosts.
-
-        So that we don't create unnecessary load on server while checking state of
-        provisioning.
-
-        returns (initial_sleep, sleep)
-        """
-        count = len(hosts)
-
-        init_poll = self.poll_sleep_initial
-        poll = self.poll_sleep
-
-        # initial poll is the biggest performance saver it should be around
-        # time when more than half of host is in ACTIVE state
-        init_poll = init_poll + 0.65 * count
-
-        # poll time should ask often enough, to not create unnecessary delays
-        # while not that many to not load the server much
-        poll = poll + 0.22 * count
-
-        return init_poll, poll
-
-    async def provision_hosts(self, hosts):
-        """Provision hosts based on list of host requirements.
-
-        Main provider method for provisioning.
-
-        First it validates that host requirements are valid and that OpenStack tenant
-        has enough resources(quota).
-
-        Then issues provisioning and waits for it succeed. Raises exception if any of
-        the servers was not successfully provisioned. If that happens it issues deletion
-        of all already provisioned resources.
-
-        Return list of information about provisioned servers.
-        """
-        logger.info("Validating hosts definitions")
-        await self.validate_hosts(hosts)
-        logger.info("Host definitions valid")
-
-        logger.info("Checking available resources")
-        can = await self.can_provision(hosts)
-        if not can:
-            raise ValidationError("Not enough resources to provision")
-        logger.info("Resource availability: OK")
-
-        started = datetime.now()
-
-        count = len(hosts)
-        logger.info(f"Issuing provisioning of {count} hosts")
-        create_aws = []
-        for req in hosts:
-            aws = self.create_server(req)
-            create_aws.append(aws)
-        create_resps = await asyncio.gather(*create_aws)
-        logger.info("Provisioning issued")
-
-        logger.info("Waiting for all hosts to be available")
-        init_poll_sleep, poll_sleep = self.get_poll_sleep_times(hosts)
-        wait_aws = []
-        for create_resp in create_resps:
-            aws = self.wait_till_provisioned(
-                create_resp.get("id"),
-                poll_sleep=poll_sleep,
-                poll_sleep_initial=init_poll_sleep,
-            )
-            wait_aws.append(aws)
-
-        server_results = await asyncio.gather(*wait_aws)
-        provisioned = datetime.now()
-        provi_duration = provisioned - started
-
-        logger.info("All hosts reached provisioning final state (ACTIVE or ERROR)")
-        logger.info(f"Provisioning duration: {provi_duration}")
-
-        errors = [res for res in server_results if res["status"] == "ERROR"]
-        if errors:
-            logger.info("Some host did not start properly")
-            for err in errors:
-                self.print_basic_info(err)
-            logger.info("Given the error, will delete all hosts")
-            await self.delete_hosts(server_results)
-            raise ProvisioningError(errors)
-
-        hosts = [self.to_host(srv) for srv in server_results]
-        for host in hosts:
-            logger.info(host)
-        return hosts
-
     async def delete_host(self, host):
         """Issue deletion of host(server) from OpenStack."""
         logger.info(f"Deleting OpenStack host {host.id}")
         await self.delete_server(host._id)
         return True
 
-    async def delete_hosts(self, hosts):
-        """Issue deletion of all servers based on previous results from provisioning."""
-        logger.info("Issuing OpenStack deletion")
-        delete_aws = []
-        for host in hosts:
-            aws = self.delete_host(host)
-            delete_aws.append(aws)
-        results = await asyncio.gather(*delete_aws)
-        logger.info("All servers issued to be deleted")
-        return results
+    def prov_result_to_host_data(self, prov_result):
+        """Get needed host infromation from openstack provisioning result."""
+        result = {
+            "id": None,
+            "name": None,
+            "addresses": None,
+            "status": None,
+            "fault": None,
+        }
 
-    def to_host(self, provisioning_result):
-        """Transform provisioning result into Host object."""
-        networks = provisioning_result.get("addresses", {})
-        addresses = [ip.get("addr") for n in networks.values() for ip in n]
-        fault = provisioning_result.get("fault")
-        status = STATUS_MAP.get(provisioning_result.get("status"), STATUS_OTHER)
+        result["id"] = prov_result.get("id")
+        result["name"] = prov_result.get("name")
+        networks = prov_result.get("addresses", {})
+        result["addresses"] = [ip.get("addr") for n in networks.values() for ip in n]
+        result["fault"] = prov_result.get("fault")
+        result["status"] = self.STATUS_MAP.get(prov_result.get("status"), STATUS_OTHER)
 
-        host = Host(
-            self,
-            provisioning_result.get("id"),
-            provisioning_result.get("name"),
-            addresses,
-            status,
-            provisioning_result,
-            error_obj=fault,
-        )
-        return host
+        return result

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 """General Provider interface."""
+import asyncio
+import logging
+from datetime import datetime
+
+from mrack.errors import ProvisioningError, ValidationError
+from mrack.host import STATUS_OTHER, Host
+
+logger = logging.getLogger(__name__)
 
 
 class Provider:
@@ -21,6 +29,7 @@ class Provider:
     def __init__(self, provisioning_config, job_config):
         """Initialize provider."""
         self._name = "dummy"
+        self.STATUS_MAP = {"OTHER": STATUS_OTHER}
         return
 
     @property
@@ -30,16 +39,118 @@ class Provider:
 
     async def validate_hosts(self, hosts):
         """Validate that host requirements are well specified."""
-        return
+        raise NotImplementedError()
 
     async def can_provision(self, hosts):
         """Check that provider has enough resources to provison hosts."""
         raise NotImplementedError()
 
-    async def provision_hosts(self, hosts):
-        """Provision hosts and wait for it to finish."""
+    async def create_server(self, req):
+        """Request and create resource on selected provider."""
         raise NotImplementedError()
 
-    async def delete_hosts(self, provisioning_results):
-        """Delete provisioned hosts based on input from provision_hosts."""
+    async def wait_till_provisioned(self, resource):
+        """Wait till resource is provisioned."""
         raise NotImplementedError()
+
+    async def provision_hosts(self, hosts):
+        """Provision hosts based on list of host requirements.
+
+        Main provider method for provisioning.
+
+        First it validates that host requirements are valid and that
+        provider has enough resources(quota).
+
+        Then issues provisioning and waits for it succeed. Raises exception if any of
+        the servers was not successfully provisioned. If that happens it issues deletion
+        of all already provisioned resources.
+
+        Return list of information about provisioned servers.
+        """
+        logger.info("Validating hosts definitions")
+        await self.validate_hosts(hosts)
+        logger.info("Host definitions valid")
+
+        logger.info("Checking available resources")
+        can = await self.can_provision(hosts)
+        if not can:
+            raise ValidationError("Not enough resources to provision")
+        logger.info("Resource availability: OK")
+
+        started = datetime.now()
+
+        count = len(hosts)
+        logger.info(f"Issuing provisioning of {count} hosts")
+        create_servers = []
+        for req in hosts:
+            awaitable = self.create_server(req)
+            create_servers.append(awaitable)
+        create_resps = await asyncio.gather(*create_servers)
+        logger.info("Provisioning issued")
+
+        logger.info("Waiting for all hosts to be available")
+        wait_servers = []
+        for create_resp in create_resps:
+            awaitable = self.wait_till_provisioned(create_resp)
+            wait_servers.append(awaitable)
+
+        server_results = await asyncio.gather(*wait_servers)
+        provisioned = datetime.now()
+        provi_duration = provisioned - started
+
+        logger.info("All hosts reached provisioning final state (ACTIVE or ERROR)")
+        logger.info(f"Provisioning duration: {provi_duration}")
+
+        errors = self.parse_errors(server_results)
+        if errors:
+            logger.info("Some host did not start properly")
+            for err in errors:
+                self.print_basic_info(err)
+            logger.info("Given the error, will delete all hosts")
+            await self.delete_hosts(server_results)
+            raise ProvisioningError(errors)
+
+        hosts = [self.to_host(srv) for srv in server_results]
+        for host in hosts:
+            logger.info(host)
+        return hosts
+
+    def parse_errors(self, server_results):
+        """Parse provisioning errors from provider result."""
+        raise NotImplementedError()
+
+    async def delete_host(self, host):
+        """Delete provisioned host."""
+        raise NotImplementedError()
+
+    async def delete_hosts(self, hosts):
+        """Issue deletion of all servers based on previous results from provisioning."""
+        logger.info("Issuing deletion")
+
+        delete_servers = []
+        for host in hosts:
+            awaitable = self.delete_host(host)
+            delete_servers.append(awaitable)
+        results = await asyncio.gather(*delete_servers)
+        logger.info("All servers issued to be deleted")
+        return results
+
+    def prov_result_to_host_data(self, prov_result):
+        """Transform provisioning result to needed host data."""
+        raise NotImplementedError()
+
+    def to_host(self, provisioning_result, username=None):
+        """Transform provisioning result into Host object."""
+        host_info = self.prov_result_to_host_data(provisioning_result)
+
+        host = Host(
+            self,
+            host_info.get("id"),
+            host_info.get("name"),
+            host_info.get("addresses"),
+            self.STATUS_MAP.get(host_info.get("status"), STATUS_OTHER),
+            provisioning_result,
+            username=username,
+            error_obj=host_info.get("fault"),
+        )
+        return host

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-black
+black==20.8b1
 isort
 flake8
 pytest


### PR DESCRIPTION
Methods provision_hosts, delete_hosts and to_host
were moved to provider.py as they can be easily
shared among the providers.

Added missing methods to provider.py to share
same structure. Not implemented methods will throw
a NotImplementedError() and they are ment to be
implmented per provider.

Moved host count to initialization of openstack
provider to set poll sleeps based on this.

For all providers moved STATUS_MAP to class
so from now on it is a class attribute.

Openstack's wait_till_provisioned now uses
instance and not only id to match inherited method.

Added optional username parameter to to_host method.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>